### PR TITLE
Add revalidation path for organizations

### DIFF
--- a/src/lib/actions/update-organization-action.ts
+++ b/src/lib/actions/update-organization-action.ts
@@ -35,6 +35,7 @@ export default async function updateOrganizationAction(organizationId: number, s
 	}
 
 	revalidatePath('/my');
+	revalidatePath('/organizations');
 
 	return {
 		...state,


### PR DESCRIPTION
The update-organization-action.ts file has been modified to include a revalidation  for the '/organizations' path, so the public organization display updates whenever an organization is updated.