### PR TITLE
Add webpage display to organization card

### DIFF
--- a/src/app/(main)/organizations/organization-card.tsx
+++ b/src/app/(main)/organizations/organization-card.tsx
@@ -10,6 +10,7 @@ import XLogo from 'public/logos/x.png';
 import TikTokLogo from 'public/logos/tiktok.png';
 import LinkedInLogo from 'public/logos/linkedin.png';
 import YoutubeLogo from 'public/logos/youtube.png';
+import Public from '@material-design-icons/svg/round/public.svg';
 import SocialLink from '@/components/social-link.tsx';
 import Paper from '@/components/paper/paper.tsx';
 
@@ -67,6 +68,17 @@ export default function OrganizationCard(props: OrganizationCardProps) {
 				}
 
 				{
+					organization.webpage && (
+						<>
+							<div>
+								<Public className='fill-current mx-auto'/>
+							</div>
+							{organization.webpage}
+						</>
+					)
+				}
+
+				{
 					organization.address && (
 						<>
 							<div>
@@ -77,7 +89,7 @@ export default function OrganizationCard(props: OrganizationCardProps) {
 					)
 				}
 			</div>
-			<div className='col-span-2 flex flex-wrap gap-x-2 gap-y-8 my-2 w-full justify-evenly'>
+			<div className='col-span-2 flex flex-wrap gap-x-2 gap-y-8 mt-4 mb-2 w-full justify-evenly'>
 				{
 					organization.facebook && (
 						<SocialLink


### PR DESCRIPTION
A webpage section has been added to the organization card component. Now, if an organization has a webpage, a corresponding icon and the webpage URL will be displayed. The flex gap and margins in the social links section have also been adjusted for better visual balance.